### PR TITLE
Set correct token in reusable-build-container-images.yml

### DIFF
--- a/.github/workflows/reusable-build-container-images.yml
+++ b/.github/workflows/reusable-build-container-images.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PACKAGE_PUBLICATION_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:


### PR DESCRIPTION
# Description

Fixes permission issues in github workflow

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
