### PR TITLE
Add workflow to create tag based on .version file updates

### DIFF
--- a/.github/workflows/tag-from-version.yml
+++ b/.github/workflows/tag-from-version.yml
@@ -2,6 +2,7 @@ name: Create Tag from .version File
 permissions: read-all
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - ".version"  # Trigger only when the .version file changes


### PR DESCRIPTION
This adds a workflow that will be triggered if the `.version` file is updated. It will keep that file and git tags in sync

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
