### PR TITLE
set fail-fast to false for reusable-build-container-images.yml

### DIFF
--- a/.github/workflows/reusable-build-container-images.yml
+++ b/.github/workflows/reusable-build-container-images.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
+        fail-fast: false
         image:
           - context: ./src/loaders/curl
             name: loaders-curl


### PR DESCRIPTION
# Description

Make sure that containers are build regardless of other containers failing to build

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
