### PR TITLE
fix: use recommended labels for k8s generator

### DIFF
--- a/scripts/generators/k8s/templates/databases/deployment.yaml.j2
+++ b/scripts/generators/k8s/templates/databases/deployment.yaml.j2
@@ -3,19 +3,19 @@ kind: Deployment
 metadata:
   name: {{ serviceName }}
   labels:
-    app: {{ appName|default('AppSimulatorApp') }}
-    service: {{ serviceName }}
+    app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+    app.kubernetes.io/name: {{ serviceName }}
 spec:
   replicas: {{ instances|default('1') }}
   selector:
     matchLabels:
-      app: {{ appName|default('AppSimulatorApp') }}
-      service: {{ serviceName }}
+      app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+      app.kubernetes.io/name: {{ serviceName }}
   template:
     metadata:
       labels:
-        app: {{ appName|default('AppSimulatorApp') }}
-        service: {{ serviceName }}
+        app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+        app.kubernetes.io/name: {{ serviceName }}
     spec:
       containers:
       - name: db-container

--- a/scripts/generators/k8s/templates/databases/service.yaml.j2
+++ b/scripts/generators/k8s/templates/databases/service.yaml.j2
@@ -11,8 +11,8 @@ metadata:
 {% endif %}
 spec:
   selector:
-    app: {{ appName|default('AppSimulatorApp') }}
-    service: {{ serviceName }}
+    app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+    app.kubernetes.io/name: {{ serviceName }}
   ports:
     - protocol: TCP
 {%- if type == 'mysql' %}
@@ -36,8 +36,8 @@ metadata:
 {% endif %}
 spec:
   selector:
-    app: {{ appName|default('AppSimulatorApp') }}
-    service: {{ serviceName }}
+    app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+    app.kubernetes.io/name: {{ serviceName }}
   ports:
     - protocol: TCP
 {%- if type == 'mysql' %}

--- a/scripts/generators/k8s/templates/loaders/deployment.yaml.j2
+++ b/scripts/generators/k8s/templates/loaders/deployment.yaml.j2
@@ -3,8 +3,8 @@ kind: Deployment
 metadata:
   name: {{ serviceName }}
   labels:
-    app: {{ appName|default('AppSimulatorApp') }}
-    service: {{ serviceName }}
+    app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+    app.kubernetes.io/name: {{ serviceName }}
   {%- if deploymentAnnotations %}
   annotations:
   {%- for k,v in deploymentAnnotations.items() %}   
@@ -15,13 +15,13 @@ spec:
   replicas: {{ instances|default('1') }}
   selector:
     matchLabels:
-      app: {{ appName|default('AppSimulatorApp') }}
-      service: {{ serviceName }}
+      app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+      app.kubernetes.io/name: {{ serviceName }}
   template:
     metadata:
       labels:
-        app: {{ appName|default('AppSimulatorApp') }}
-        service: {{ serviceName }}
+        app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+        app.kubernetes.io/name: {{ serviceName }}
     spec:
       containers:
       - name: loader-container

--- a/scripts/generators/k8s/templates/services/deployment.yaml.j2
+++ b/scripts/generators/k8s/templates/services/deployment.yaml.j2
@@ -3,19 +3,19 @@ kind: Deployment
 metadata:
   name: {{ serviceName }}
   labels:
-    app: {{ appName|default('AppSimulatorApp') }}
-    service: {{ serviceName }}
+    app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+    app.kubernetes.io/name: {{ serviceName }}
 spec:
   replicas: {{ instances|default('1') }}
   selector:
     matchLabels:
-      app: {{ appName|default('AppSimulatorApp') }}
-      service: {{ serviceName }}
+      app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+      app.kubernetes.io/name: {{ serviceName }}
   template:
     metadata:
       labels:
-        app: {{ appName|default('AppSimulatorApp') }}
-        service: {{ serviceName }}
+        app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+        app.kubernetes.io/name: {{ serviceName }}
 {%- if deploymentAnnotations %}
       annotations:
 {%- for k,v in deploymentAnnotations.items() %}   

--- a/scripts/generators/k8s/templates/services/service.yaml.j2
+++ b/scripts/generators/k8s/templates/services/service.yaml.j2
@@ -11,8 +11,8 @@ metadata:
 {% endif %}
 spec:
   selector:
-    app: {{ appName|default('AppSimulatorApp') }}
-    service: {{ serviceName }}
+    app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+    app.kubernetes.io/name: {{ serviceName }}
   ports:
     - protocol: TCP
       targetPort: {{ servicePort|default('8080') }}


### PR DESCRIPTION
# Description

This should fix https://github.com/cisco-open/app-simulator/issues/122 by using K8s recommended labels.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
