### PR TITLE
Syntax error in curl loader dockerfile

### DIFF
--- a/src/loaders/curl/Dockerfile
+++ b/src/loaders/curl/Dockerfile
@@ -10,5 +10,5 @@ LABEL org.opencontainers.image.licenses=BSD-3-Clause
 RUN apk add --no-cache bash curl util-linux jq
 WORKDIR /usr/bin
 COPY entrypoint.sh /usr/bin/entrypoint.sh
-RUN chmod +x /usr/bin//entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]


### PR DESCRIPTION
# Description

When using Docker-compose, the curl loader container was not really starting.

log error

exec /usr/bin/entrypoint.sh: no such file or directory

--> typo error in the Dockerfile

## Type of Change

- [x ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
