### PR TITLE
fix: make sure that docker compose generator also uses `exposedPort`

### DIFF
--- a/docs/quick-start/docker-compose/README.md
+++ b/docs/quick-start/docker-compose/README.md
@@ -19,7 +19,7 @@ in a new folder:
 services:
   frontend:
     type: java
-    port: 3000
+    exposedPort: 3000
     endpoints:
       http:
         /upload:

--- a/docs/tutorial/1-two-services.md
+++ b/docs/tutorial/1-two-services.md
@@ -56,7 +56,7 @@ simulation:
 - For docker compose run
 
   ```shell
-  docker run --rm -t -i -v ${PWD}:/mnt cisco-open/app-simulator-generators-docker-compose --config /mnt/config.yaml --output /mnt/docker-compose.yaml
+  docker run --rm -t -i -v ${PWD}:/mnt cisco-open/app-simulator-generators-docker-compose:latest --config /mnt/config.yaml --output /mnt/docker-compose.yaml
   docker compose up
   ```
 
@@ -66,3 +66,5 @@ simulation:
   docker run --rm -t -i -v ${PWD}/deployments:/app/deployments -v ${PWD}:/mnt ghcr.io/cisco-open/app-simulator-generators-k8s:latest --config /mnt/config.yaml
   kubectl apply -f deployments/
   ```
+
+In both cases you will be see three containers being started. 

--- a/scripts/generators/docker-compose/docker-compose.j2
+++ b/scripts/generators/docker-compose/docker-compose.j2
@@ -4,9 +4,9 @@ services:
   {%- for name, details in scopeDetails.items() %}
   {{ name }}:
     image: {{ global.imageNamePrefix }}app-simulator-{{ scope }}-{{ details.type }}:{{global.imageVersion }}
-    {%- if details.port is defined %}
+    {%- if details.exposedPort is defined %}
     ports:
-      - "{{ details.port }}:{{ global.defaultPorts[scope] }}"
+      - "{{ details.exposedPort }}:{{ global.defaultPorts[scope] }}"
     {%- endif %}
     {%- if global.defaultPorts is defined -%}
     {%- if global.defaultPorts[scope] is defined and global.defaultPorts[scope] != global._defaultDefaultPorts[scope] %}


### PR DESCRIPTION
# Description

Updates the docker compose generator to also use `exposedPort` to define the port that will be used to make a service locally accessible

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
