### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
-*   @cisco-open/app-simulator-admins
+# Maintainers are responsible for the code of the project and asked to review
+*           @cisco-open/app-simulator-maintainers
+# The .github repo contains CI, settings, etc and changes should be reviewed and approved by admins
+/.github/   @cisco-open/app-simulator-admins


### PR DESCRIPTION
# Description

Updates the codeowner file as outlined in the comments: maintainers are the main point of contact, admins own the .github repo 


