### PR TITLE
follow up fixes for recommended labels

### DIFF
--- a/scripts/generators/k8s/templates/services/deployment.yaml.j2
+++ b/scripts/generators/k8s/templates/services/deployment.yaml.j2
@@ -42,7 +42,7 @@ spec:
           valueFrom:
             fieldRef:
               apiVersion: v1
-              fieldPath: metadata.labels['service']
+              fieldPath: metadata.labels['app.kubernetes.io/name']
         ports:
         - containerPort: {{ service_port|default('8080') }}
         resources:

--- a/scripts/generators/k8s/templates/services/service.yaml.j2
+++ b/scripts/generators/k8s/templates/services/service.yaml.j2
@@ -31,8 +31,8 @@ metadata:
 {% endif %}
 spec:
   selector:
-    app: {{ appName|default('AppSimulatorApp') }}
-    service: {{ serviceName }}
+    app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
+    app.kubernetes.io/name: {{ serviceName }}
   ports:
     - protocol: TCP
       targetPort: {{ servicePort|default('8080') }}


### PR DESCRIPTION
# Description

Fixes some issues with the recently merged PR that changes labels for the k8s generator. I missed updating a few fields, which lead to issues with running the appsim.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)