### PR TITLE
add type and language labels to k8s deployment templates

### DIFF
--- a/scripts/generators/k8s/templates/databases/deployment.yaml.j2
+++ b/scripts/generators/k8s/templates/databases/deployment.yaml.j2
@@ -5,6 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
     app.kubernetes.io/name: {{ serviceName }}
+    app.kubernetes.io/component: database
+    app-simulator.org/type: {{ type }}
 spec:
   replicas: {{ instances|default('1') }}
   selector:

--- a/scripts/generators/k8s/templates/loaders/deployment.yaml.j2
+++ b/scripts/generators/k8s/templates/loaders/deployment.yaml.j2
@@ -5,6 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
     app.kubernetes.io/name: {{ serviceName }}
+    app.kubernetes.io/component: loader
+    app-simulator.org/type: {{ type }}
   {%- if deploymentAnnotations %}
   annotations:
   {%- for k,v in deploymentAnnotations.items() %}   

--- a/scripts/generators/k8s/templates/services/deployment.yaml.j2
+++ b/scripts/generators/k8s/templates/services/deployment.yaml.j2
@@ -5,6 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/part-of: {{ appName|default('AppSimulatorApp') }}
     app.kubernetes.io/name: {{ serviceName }}
+    app.kubernetes.io/component: service
+    app-simulator.org/type: {{ type|default('java') }}
 spec:
   replicas: {{ instances|default('1') }}
   selector:


### PR DESCRIPTION
# Description

This fixes #147 by introducing 2 additional labels to the deployments, one for the component and one for the type

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
